### PR TITLE
Oppgraderer Distroless til java21-debian13@sha256:53ce8e6a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:f34fd3e4e2d7a246d764d0614f5e6ffb3a735930723fac4cfc25a72798950262
+FROM gcr.io/distroless/java21-debian13@sha256:53ce8e6ab58ff683ec8de330610605a8d0a2d12135d3a1b79fe53290eb1999f2
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"
 


### PR DESCRIPTION
Fra flex-cli